### PR TITLE
Updated path for example-file.zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Utils has multiple token types. Types are space, radius and shadow. See how to n
 ## How to install 
 
 - Download the [design-tokens.sketchplugin.zip](https://github.com/vjandrei/Design-Tokens/releases/latest). Extract zip and double-click the `design-tokens.sketchplugin` file
-- Download the [example-file.zip](https://github.com/vjandrei/Design-Tokens/releases/latest). Extract zip and double-click the `design-tokens.sketch` file
+- Download the [example-file.zip](https://github.com/vjandrei/Design-Tokens/releases/download/0.0.1/example-file.zip). Extract zip and double-click the `design-tokens.sketch` file
 
 ## Roadmap
 


### PR DESCRIPTION
example-file.zip is only in the first release, so updated the link to target the zip file.